### PR TITLE
Fixed origin parameter

### DIFF
--- a/robots/wsg_32_description.urdf.xacro
+++ b/robots/wsg_32_description.urdf.xacro
@@ -4,7 +4,7 @@
 <xacro:macro name="wsg_32_xacro" params="name parent *origin">
 
   <joint name="${name}_base_joint" type="fixed">
-    <insert_block name="origin"/>
+    <xacro:insert_block name="origin"/>
     <parent link="${parent}"/>
     <child link="${name}_base_link"/>
   </joint>


### PR DESCRIPTION
Xacro macro tag
`<xacro:insert_block name="origin"/>`

instead of useless tag
`<insert_block name="origin"/>`